### PR TITLE
feature/sessions-fetch-by-teacher-class-subject

### DIFF
--- a/src/apps/schedules/routes/sessions_subjects/sessions_subjects_route.py
+++ b/src/apps/schedules/routes/sessions_subjects/sessions_subjects_route.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.apps.schedules.model.sessions_subjects.sessions_subjects_schema import (
@@ -49,3 +49,45 @@ async def delete_session_subject(
     current_user=Depends(SecurityHelper.require_role("admin"))
 ):
     return await SessionSubjectService.delete_session_subject(session_subject_id, session)
+
+
+@router.get("/teacher/{teacher_id}", response_model=list[SessionSubjectResponse])
+async def get_teacher_sessions(
+    teacher_id: int,
+    session: AsyncSession = Depends(get_db),
+    current_user=Depends(SecurityHelper.get_current_user)
+):
+    user_id = int(current_user['sub'])  
+    user_role = current_user['role']   
+
+    if user_role == "admin":
+        pass 
+    elif user_role == "teacher":
+        if user_id != teacher_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, 
+                detail="Teacher cannot access sessions of another teacher."
+            )
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, 
+            detail="You do not have permission to access these sessions."
+        )
+
+    return await SessionSubjectService.get_teacher_sessions(teacher_id, session)
+
+@router.get("/class/{class_id}", response_model=list[SessionSubjectResponse])
+async def get_class_sessions(
+    class_id: int,
+    session: AsyncSession = Depends(get_db),
+    current_user=Depends(SecurityHelper.require_role("admin"))
+):
+    return await SessionSubjectService.get_class_sessions(class_id, session)
+
+@router.get("/subject/{subject_id}", response_model=list[SessionSubjectResponse])
+async def get_subject_sessions(
+    subject_id: int,
+    session: AsyncSession = Depends(get_db),
+    current_user=Depends(SecurityHelper.require_role("admin"))
+):
+    return await SessionSubjectService.get_subject_sessions(subject_id, session)


### PR DESCRIPTION
feat: Add session retrieval by teacher, class, and subject

- Implemented three new routes to fetch SessionSubject records:
  1. GET /sessions-subjects/teacher/{teacher_id} — accessible to the teacher themself or an admin.
  2. GET /sessions-subjects/class/{class_id} — restricted to admin role.
  3. GET /sessions-subjects/subject/{subject_id} — restricted to admin role.
- Updated SessionSubjectService with new methods (get_teacher_sessions, get_class_sessions, get_subject_sessions).
- Ensured consistent role-based access control:
  - Admin can retrieve any sessions.
  - Teacher can only retrieve their own sessions (teacher_id).
- Enhanced error handling and logging to provide clear messages for unauthorized access and invalid foreign keys.
- Maintained orm_mode-based serialization, removing the need for manual data transformers.
